### PR TITLE
Trivy導入

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ env:
   OPA_VERSION: 0.64.1
   CONFTEST_VERSION: 0.51.0
   REGAL_VERSION: 0.21.3
+  TRIVY_VERSION: 0.51.1
 
 jobs:
   test:
@@ -71,6 +72,25 @@ jobs:
       - name: run conftest
         run: |
           ./scripts/conftest.sh
+
+      # 既にインストール済みのTtrivyがキャッシュに存在する場合restore
+      - name: cache trivy CLI
+        id: trivy-cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        with:
+          path: |
+            /usr/local/bin/trivy
+          key: trivy-${{ env.TRIVY_VERSION }}
+
+      # キャッシュにTrivyが存在しない場合インストール
+      - name: install trivy if the cache doesn't exist
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v${{ env.TRIVY_VERSION }}
+
+      # Trivyによるセキュリティスキャンを実行
+      - name: run trivy
+        run: |
+          ./scripts/trivy.sh
 
   slack:
     if: always()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,9 @@ repos:
         entry: ./scripts/conftest.sh
         language: system
         always_run: true
+      # 脆弱性DBのアップデートなどが発生する場合、チェックに時間がかかるので必要に応じてCIに任せる
+      - id: trivy
+        name: run trivy
+        entry: ./scripts/trivy.sh
+        language: system
+        always_run: true

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,9 @@
+# avd-gcp-0001を除外したい場合、大文字でAVD-GCP-0001と指定しないと除外できない
+# コードに`#trivy:ignore`コメントを追加することでも特定のルールチェックを行わないようにすることが可能
+misconfigurations:
+
+secrets:
+
+vulnerabilities:
+
+licenses:

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ $ cd /path/to/your-infra-project
 # なお各自のプロジェクトでGit管理されないようにするために.gitignoreでorg-policiesを定義する必要がある
 $ conftest pull git::https://github.com/erueru-tech/infra-policy-example.git//policy -p org-policies
 
-# org-policiesディレクトリ内に定義された全ポリシーテストを実行
-$ conftest test -p org-policies --all-namespaces .
+# org-policies/conftestディレクトリ内に定義された全ポリシーテストを実行
+$ conftest test -p org-policies/conftest --all-namespaces .
 ```
 
 (組織内のインフラプロジェクトでポリシーテストを実行するための共有 Github Action はいずれ実装予定)
@@ -31,6 +31,7 @@ $ conftest test -p org-policies --all-namespaces .
 - [OPA](https://www.openpolicyagent.org/docs/latest/#1-download-opa) v0.64.1
 - [Regal](https://github.com/StyraInc/regal?tab=readme-ov-file#download-regal) v0.21.3
 - [Conftest](https://www.conftest.dev/install/) v0.51.0
+- [Trivy](https://aquasecurity.github.io/trivy/latest/getting-started/installation/) v0.51.1
 
 各ツールのインストール手順は公式ドキュメントを参照してください。
 
@@ -57,3 +58,7 @@ $ ./scripts/opafmt.sh
 ```bash
 $ ./scripts/regal.sh
 ```
+
+## 情報
+
+設計に関する詳細は[ブログ](https://zenn.dev/erueru_tech)などで公開していますので、興味のある方はそちらを確認してください。

--- a/conftest.toml
+++ b/conftest.toml
@@ -1,6 +1,3 @@
-# Regoのプログラム内で、必要に応じて使うデータ(JSON、YAML等)がまとめられているディレクトリのパス
-# FIXME dataディレクトリを実際使用することになったらアンコメント
-#data = "policy/data"
 # ポリシーのテスト対象から除外するファイル、ディレクトリ
 # .gitや.terraformに生成されるファイルは自分で作ったファイルではないのでチェックから除外
 ignore = ".git/|.terraform/|LICENSE"

--- a/scripts/trivy.sh
+++ b/scripts/trivy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eu
+
+trivy fs ./

--- a/trivy-secret.yaml
+++ b/trivy-secret.yaml
@@ -1,0 +1,8 @@
+# デフォルトの設定だとSecret情報がMarkDownファイルに含まれている場合でもエラーが発生しないといった挙動になる
+# 以下のように設定することで、より厳密なSecret情報の混入チェックが可能となる
+# ref. https://aquasecurity.github.io/trivy/latest/docs/scanner/secret/
+# ref. https://github.com/aquasecurity/trivy/blob/main/pkg/fanal/secret/builtin-allow-rules.go
+disable-allow-rules:
+  - markdown
+  - tests
+  - examples

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,17 @@
+# ref. https://aquasecurity.github.io/trivy/v0.51/docs/references/configuration/config-file/
+
+# Report Options #
+# Trivyで問題を検知した場合にエラー終了させるための設定
+exit-code: 1
+# デフォルトは.trivyignoreだが、YAMLフォーマットで定義できるように変更
+ignorefile: .trivyignore.yaml
+
+# Scan Options #
+scan:
+  # 基本的なスキャン機能をすべて使用
+  # ref. https://aquasecurity.github.io/trivy/v0.51/docs/scanner/vulnerability/
+  scanners:
+    - vuln
+    - misconfig
+    - secret
+    - license


### PR DESCRIPTION
### 概要

以下を対応。

- Trivyのセキュリティスキャンを導入
- インフラプロジェクト側でのポリシーテストの実行コマンドをConftestのポリシーのみダウンロードするように修正